### PR TITLE
Refactor sensory cortex to use perception encoders

### DIFF
--- a/modules/brain/sensory_cortex.py
+++ b/modules/brain/sensory_cortex.py
@@ -1,118 +1,366 @@
-class EdgeDetector:
-    """Simple edge detection placeholder."""
+from __future__ import annotations
 
-    def detect(self, image):
-        return ["edge"]
+"""Adapters for sensory cortices that expose structured encoder features.
+
+The previous implementation returned placeholder string tokens such as
+"edge" or "touch".  This module now bridges the numerically grounded encoders
+in :mod:`modules.brain.perception` to the rest of the system, providing rich
+feature dictionaries and an optional neuromorphic hand-off when a spiking
+backend is attached.
+"""
+
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
+
+import numpy as np
+
+from .perception import AuditoryEncoder, EncodedSignal, TactileEncoder, VisualEncoder
+
+
+def _as_array(vector: Sequence[float] | np.ndarray) -> np.ndarray:
+    arr = np.asarray(vector, dtype=np.float32)
+    if arr.ndim == 0:
+        arr = arr.reshape(1)
+    return arr.reshape(-1)
+
+
+def _stage_payload(stage: str, signal: EncodedSignal, extra_features: Mapping[str, float]) -> Dict[str, Any]:
+    features = {key: float(value) for key, value in signal.features.items()}
+    features.update({key: float(value) for key, value in extra_features.items()})
+    metadata = {**signal.metadata, "stage": stage}
+    return {
+        "vector": list(signal.vector),
+        "features": features,
+        "metadata": metadata,
+    }
+
+
+def _map_vector_to_neurons(vector: Sequence[float], n_neurons: int) -> List[float]:
+    if n_neurons <= 0:
+        return list(vector)
+    arr = _as_array(vector)
+    if arr.size == 0:
+        return [0.0 for _ in range(n_neurons)]
+    if arr.size == n_neurons:
+        return arr.astype(float).tolist()
+    if arr.size < n_neurons:
+        padded = np.pad(arr, (0, n_neurons - arr.size), mode="constant")
+        return padded.astype(float).tolist()
+    splits = np.array_split(arr, n_neurons)
+    return [float(split.mean()) for split in splits]
+
+
+def _normalize_for_spiking(currents: Iterable[float]) -> List[float]:
+    arr = _as_array(list(currents))
+    if arr.size == 0:
+        return []
+    min_val = float(np.min(arr))
+    if min_val < 0.0:
+        arr = arr - min_val
+    max_val = float(np.max(np.abs(arr)))
+    if max_val > 0.0 and max_val < 1.0:
+        arr = arr / max_val
+    return arr.astype(float).tolist()
+
+
+def _build_neuromorphic_payload(backend: Any, signal: EncodedSignal) -> Dict[str, Any]:
+    neurons = getattr(getattr(backend, "neurons", None), "size", 0) or 0
+
+    def _compressed(vec: Sequence[float]) -> List[float]:
+        mapped = _map_vector_to_neurons(vec, int(neurons))
+        if not mapped and neurons:
+            mapped = [0.0 for _ in range(int(neurons))]
+        return _normalize_for_spiking(mapped)
+
+    arr = _as_array(signal.vector)
+    frames = int(signal.metadata.get("frames", 0) or 0)
+    mels = int(signal.metadata.get("mels", 0) or 0)
+    input_sequence: List[List[float]]
+    if frames and mels and arr.size == frames * mels:
+        mel_matrix = arr.reshape(frames, mels)
+        input_sequence = [_compressed(row) for row in mel_matrix]
+    else:
+        input_sequence = [_compressed(signal.vector)]
+    input_sequence = [seq for seq in input_sequence if seq]
+    events = backend.run(input_sequence) if input_sequence else []
+    if hasattr(backend, "synapses") and hasattr(backend.synapses, "adapt"):
+        backend.synapses.adapt(backend.spike_times, backend.spike_times)
+    n_channels = len(input_sequence[0]) if input_sequence else len(_map_vector_to_neurons(signal.vector, int(neurons)))
+    spike_counts = [0 for _ in range(n_channels)]
+    formatted_events: List[List[Any]] = []
+    if isinstance(events, list):
+        for index, event in enumerate(events):
+            if isinstance(event, tuple) and len(event) == 2:
+                time, spikes = event
+            else:
+                time, spikes = index, event
+            spikes_list = [int(s) for s in spikes]
+            for idx, spike in enumerate(spikes_list):
+                if idx >= len(spike_counts):
+                    spike_counts.extend([0] * (idx + 1 - len(spike_counts)))
+                spike_counts[idx] += spike
+            formatted_events.append([float(time), spikes_list])
+    payload: Dict[str, Any] = {
+        "encoded_vector": list(signal.vector),
+        "inputs": input_sequence,
+        "events": formatted_events,
+        "spike_counts": spike_counts,
+    }
+    if hasattr(backend, "energy_usage"):
+        payload["energy_used"] = float(getattr(backend, "energy_usage", 0.0))
+    return payload
+
+
+class EdgeDetector:
+    """Adapter producing numeric edge-centric features via ``VisualEncoder``."""
+
+    def __init__(self, encoder: VisualEncoder | None = None) -> None:
+        self.encoder = encoder or VisualEncoder()
+
+    def detect(self, image: Any, signal: EncodedSignal | None = None) -> Dict[str, Any]:
+        encoded = signal or self.encoder.encode(image)
+        arr = _as_array(encoded.vector)
+        density = float(np.mean(arr > 0.2)) if arr.size else 0.0
+        return _stage_payload(
+            "V1",
+            encoded,
+            {
+                "edge_density": density,
+            },
+        )
 
 
 class V1:
-    def __init__(self):
-        self.edge_detector = EdgeDetector()
+    def __init__(self, encoder: VisualEncoder | None = None) -> None:
+        self.edge_detector = EdgeDetector(encoder)
 
-    def process(self, image):
-        return self.edge_detector.detect(image)
+    def process(self, image: Any, signal: EncodedSignal | None = None) -> Dict[str, Any]:
+        return self.edge_detector.detect(image, signal)
 
 
 class V2:
-    def process(self, image):
-        return ["form"]
+    def __init__(self, encoder: VisualEncoder | None = None) -> None:
+        self.encoder = encoder or VisualEncoder()
+
+    def process(self, image: Any, signal: EncodedSignal | None = None) -> Dict[str, Any]:
+        encoded = signal or self.encoder.encode(image)
+        arr = _as_array(encoded.vector)
+        if arr.size:
+            midpoint = arr.size // 2
+            left = float(arr[:midpoint].mean()) if midpoint else float(arr.mean())
+            right = float(arr[midpoint:].mean()) if midpoint else left
+            complexity = float(arr.std())
+            symmetry = float(abs(left - right))
+        else:
+            complexity = 0.0
+            symmetry = 0.0
+        return _stage_payload(
+            "V2",
+            encoded,
+            {
+                "form_complexity": complexity,
+                "form_symmetry": symmetry,
+            },
+        )
 
 
 class V4:
-    def process(self, image):
-        return ["color"]
+    def __init__(self, encoder: VisualEncoder | None = None) -> None:
+        self.encoder = encoder or VisualEncoder()
+
+    def process(self, image: Any, signal: EncodedSignal | None = None) -> Dict[str, Any]:
+        encoded = signal or self.encoder.encode(image)
+        arr = _as_array(encoded.vector)
+        color_salience = float(arr.max() - arr.min()) if arr.size else 0.0
+        return _stage_payload(
+            "V4",
+            encoded,
+            {
+                "color_salience": color_salience,
+            },
+        )
 
 
 class MT:
-    def process(self, image):
-        return ["motion"]
+    def __init__(self, encoder: VisualEncoder | None = None) -> None:
+        self.encoder = encoder or VisualEncoder()
+
+    def process(self, image: Any, signal: EncodedSignal | None = None) -> Dict[str, Any]:
+        encoded = signal or self.encoder.encode(image)
+        arr = _as_array(encoded.vector)
+        motion_energy = float(np.mean(np.abs(np.diff(arr)))) if arr.size > 1 else 0.0
+        motion_bias = float(arr[-1] - arr[0]) if arr.size > 1 else 0.0
+        return _stage_payload(
+            "MT",
+            encoded,
+            {
+                "motion_energy": motion_energy,
+                "motion_bias": motion_bias,
+            },
+        )
 
 
 class VisualCortex:
-    """Visual cortex with hierarchical processing areas."""
+    """Visual cortex with hierarchical processing areas backed by encoders."""
 
-    def __init__(self, spiking_backend=None):
-        self.v1 = V1()
-        self.v2 = V2()
-        self.v4 = V4()
-        self.mt = MT()
+    def __init__(self, spiking_backend: Any | None = None) -> None:
+        self.encoder = VisualEncoder()
+        self.v1 = V1(self.encoder)
+        self.v2 = V2(self.encoder)
+        self.v4 = V4(self.encoder)
+        self.mt = MT(self.encoder)
         self.spiking_backend = spiking_backend
 
-    def process(self, image):
-        if self.spiking_backend:
-            spikes = self.spiking_backend.run(image)
-            self.spiking_backend.synapses.adapt(
-                self.spiking_backend.spike_times, self.spiking_backend.spike_times
-            )
-            return spikes
-        return {
-            "edges": self.v1.process(image),
-            "form": self.v2.process(image),
-            "color": self.v4.process(image),
-            "motion": self.mt.process(image),
+    def process(self, image: Any) -> Dict[str, Any]:
+        encoded = self.encoder.encode(image)
+        result = {
+            "v1": self.v1.process(image, encoded),
+            "v2": self.v2.process(image, encoded),
+            "v4": self.v4.process(image, encoded),
+            "mt": self.mt.process(image, encoded),
         }
+        if self.spiking_backend:
+            result["neuromorphic"] = _build_neuromorphic_payload(
+                self.spiking_backend, encoded
+            )
+        return result
 
 
 class FrequencyAnalyzer:
-    """Placeholder frequency analyzer for auditory signals."""
+    """Adapter extracting spectral summaries with ``AuditoryEncoder``."""
 
-    def analyze(self, sound):
-        return ["frequency"]
+    def __init__(self, encoder: AuditoryEncoder | None = None) -> None:
+        self.encoder = encoder or AuditoryEncoder()
+
+    def analyze(self, sound: Any, signal: EncodedSignal | None = None) -> Dict[str, Any]:
+        encoded = signal or self.encoder.encode(sound)
+        arr = _as_array(encoded.vector)
+        frames = int(encoded.metadata.get("frames", 0) or 0)
+        mels = int(encoded.metadata.get("mels", 0) or 0)
+        if frames and mels and arr.size == frames * mels:
+            mel_matrix = arr.reshape(frames, mels)
+        elif mels and arr.size >= mels:
+            mel_matrix = arr.reshape(-1, mels)
+        else:
+            mel_matrix = arr.reshape(1, -1)
+        band_profile = mel_matrix.mean(axis=0) if mel_matrix.size else np.zeros(0)
+        if band_profile.size:
+            dominant_band = int(np.argmax(band_profile))
+            band_energy = float(band_profile[dominant_band])
+        else:
+            dominant_band = 0
+            band_energy = 0.0
+        return _stage_payload(
+            "A1",
+            encoded,
+            {
+                "dominant_band": float(dominant_band),
+                "band_energy": band_energy,
+            },
+        )
 
 
 class A1:
-    def __init__(self):
-        self.analyzer = FrequencyAnalyzer()
+    def __init__(self, encoder: AuditoryEncoder | None = None) -> None:
+        self.analyzer = FrequencyAnalyzer(encoder)
 
-    def process(self, sound):
-        return self.analyzer.analyze(sound)
+    def process(self, sound: Any, signal: EncodedSignal | None = None) -> Dict[str, Any]:
+        return self.analyzer.analyze(sound, signal)
 
 
 class A2:
-    def process(self, sound):
-        return ["interpretation"]
+    def __init__(self, encoder: AuditoryEncoder | None = None) -> None:
+        self.encoder = encoder or AuditoryEncoder()
+
+    def process(self, sound: Any, signal: EncodedSignal | None = None) -> Dict[str, Any]:
+        encoded = signal or self.encoder.encode(sound)
+        arr = _as_array(encoded.vector)
+        frames = int(encoded.metadata.get("frames", 0) or 0)
+        mels = int(encoded.metadata.get("mels", 0) or 0)
+        if frames and mels and arr.size == frames * mels:
+            mel_matrix = arr.reshape(frames, mels)
+            temporal_profile = mel_matrix.mean(axis=1)
+            temporal_variance = float(np.var(temporal_profile)) if temporal_profile.size else 0.0
+            spectral_spread = float(np.var(mel_matrix, axis=0).mean()) if mel_matrix.size else 0.0
+        else:
+            temporal_variance = float(np.var(arr)) if arr.size else 0.0
+            spectral_spread = 0.0
+        return _stage_payload(
+            "A2",
+            encoded,
+            {
+                "temporal_variance": temporal_variance,
+                "spectral_spread": spectral_spread,
+            },
+        )
 
 
 class AuditoryCortex:
     """Auditory cortex with primary and secondary areas."""
 
-    def __init__(self, spiking_backend=None):
-        self.a1 = A1()
-        self.a2 = A2()
+    def __init__(self, spiking_backend: Any | None = None) -> None:
+        self.encoder = AuditoryEncoder()
+        self.a1 = A1(self.encoder)
+        self.a2 = A2(self.encoder)
         self.spiking_backend = spiking_backend
 
-    def process(self, sound):
-        if self.spiking_backend:
-            spikes = self.spiking_backend.run(sound)
-            self.spiking_backend.synapses.adapt(
-                self.spiking_backend.spike_times, self.spiking_backend.spike_times
-            )
-            return spikes
-        return {
-            "frequencies": self.a1.process(sound),
-            "interpretation": self.a2.process(sound),
+    def process(self, sound: Any) -> Dict[str, Any]:
+        encoded = self.encoder.encode(sound)
+        result = {
+            "a1": self.a1.process(sound, encoded),
+            "a2": self.a2.process(sound, encoded),
         }
+        if self.spiking_backend:
+            result["neuromorphic"] = _build_neuromorphic_payload(
+                self.spiking_backend, encoded
+            )
+        return result
 
 
 class TouchProcessor:
-    """Placeholder somatosensory processor."""
+    """Adapter transforming tactile stimuli via ``TactileEncoder``."""
 
-    def process(self, stimulus):
-        return ["touch"]
+    def __init__(self, encoder: TactileEncoder | None = None) -> None:
+        self.encoder = encoder or TactileEncoder()
+
+    def process(self, stimulus: Any, signal: EncodedSignal | None = None) -> Dict[str, Any]:
+        encoded = signal or self.encoder.encode(stimulus)
+        arr = _as_array(encoded.vector)
+        grid_shape = encoded.metadata.get("grid")
+        if grid_shape and len(grid_shape) == 2 and arr.size == int(grid_shape[0]) * int(grid_shape[1]):
+            height, width = int(grid_shape[0]), int(grid_shape[1])
+            grid = arr.reshape(height, width)
+            central = grid[height // 2, width // 2]
+            edge_values = np.concatenate((grid[0], grid[-1], grid[:, 0], grid[:, -1]))
+            edge_pressure = float(edge_values.mean()) if edge_values.size else float(central)
+            central_pressure = float(central)
+        else:
+            central_pressure = float(arr.mean()) if arr.size else 0.0
+            edge_pressure = central_pressure
+        return _stage_payload(
+            "S1",
+            encoded,
+            {
+                "central_pressure": central_pressure,
+                "edge_pressure": edge_pressure,
+            },
+        )
 
 
 class SomatosensoryCortex:
     """Somatosensory cortex for processing tactile information."""
 
-    def __init__(self, spiking_backend=None):
-        self.processor = TouchProcessor()
+    def __init__(self, spiking_backend: Any | None = None) -> None:
+        self.encoder = TactileEncoder()
+        self.processor = TouchProcessor(self.encoder)
         self.spiking_backend = spiking_backend
 
-    def process(self, stimulus):
+    def process(self, stimulus: Any) -> Dict[str, Any]:
+        encoded = self.encoder.encode(stimulus)
+        result = {
+            "s1": self.processor.process(stimulus, encoded),
+        }
         if self.spiking_backend:
-            spikes = self.spiking_backend.run(stimulus)
-            self.spiking_backend.synapses.adapt(
-                self.spiking_backend.spike_times, self.spiking_backend.spike_times
+            result["neuromorphic"] = _build_neuromorphic_payload(
+                self.spiking_backend, encoded
             )
-            return spikes
-        return self.processor.process(stimulus)
+        return result

--- a/tests/test_sensory_cortex.py
+++ b/tests/test_sensory_cortex.py
@@ -1,33 +1,107 @@
 import os
 import sys
 
+import numpy as np
+import pytest
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from modules.brain import VisualCortex, AuditoryCortex, SomatosensoryCortex
 from modules.brain.neuromorphic.spiking_network import SpikingNeuralNetwork
 
 
-def test_visual_cortex():
+@pytest.fixture
+def checkerboard_image() -> np.ndarray:
+    return np.array([[0.0, 1.0], [1.0, 0.0]], dtype=np.float32)
+
+
+@pytest.fixture
+def tone_signal() -> np.ndarray:
+    t = np.linspace(0, 1, 1600, dtype=np.float32)
+    carrier = 0.6 * np.sin(2 * np.pi * 10 * t) + 0.3 * np.sin(2 * np.pi * 40 * t)
+    modulation = np.linspace(0.2, 1.0, t.size, dtype=np.float32)
+    return (carrier * modulation).astype(np.float32)
+
+
+@pytest.fixture
+def tactile_grid() -> np.ndarray:
+    return np.array([[0.0, 0.4, 0.8], [0.2, 0.6, 1.0]], dtype=np.float32)
+
+
+def test_visual_cortex_features(checkerboard_image: np.ndarray) -> None:
     cortex = VisualCortex()
-    result = cortex.process("image data")
-    assert "edges" in result and "color" in result
+    result = cortex.process(checkerboard_image)
+
+    assert set(result.keys()) == {"v1", "v2", "v4", "mt"}
+    for stage in result.values():
+        assert isinstance(stage["vector"], list)
+        assert isinstance(stage["features"], dict)
+        assert stage["metadata"]["stage"] in {"V1", "V2", "V4", "MT"}
+
+    v1_features = result["v1"]["features"]
+    assert v1_features["edge_density"] == pytest.approx(0.546875, rel=1e-6)
+    assert v1_features["edge_energy"] == pytest.approx(0.19950187, rel=1e-6)
+
+    mt_features = result["mt"]["features"]
+    assert mt_features["motion_energy"] == pytest.approx(0.02034884, rel=1e-6)
+    assert mt_features["motion_bias"] == pytest.approx(0.0, abs=1e-6)
 
 
-def test_auditory_cortex():
+def test_auditory_cortex_features(tone_signal: np.ndarray) -> None:
     cortex = AuditoryCortex()
-    result = cortex.process("audio data")
-    assert "frequencies" in result and "interpretation" in result
+    result = cortex.process(tone_signal)
+
+    assert set(result.keys()) == {"a1", "a2"}
+    a1_features = result["a1"]["features"]
+    assert a1_features["dominant_band"] == pytest.approx(1.0, abs=1e-6)
+    assert a1_features["band_energy"] == pytest.approx(5.507319, rel=1e-6)
+
+    a2_features = result["a2"]["features"]
+    assert a2_features["temporal_variance"] == pytest.approx(2.1737657, rel=1e-6)
+    assert a2_features["spectral_spread"] == pytest.approx(4.3831153, rel=1e-6)
 
 
-def test_somatosensory_cortex():
+def test_somatosensory_cortex_features(tactile_grid: np.ndarray) -> None:
     cortex = SomatosensoryCortex()
-    result = cortex.process("stimulus")
-    assert result == ["touch"]
+    result = cortex.process(tactile_grid)
+
+    assert set(result.keys()) == {"s1"}
+    s1_features = result["s1"]["features"]
+    assert s1_features["central_pressure"] == pytest.approx(0.5714286, rel=1e-6)
+    assert s1_features["edge_pressure"] == pytest.approx(0.5, rel=1e-6)
+    assert s1_features["mean_pressure"] == pytest.approx(0.5, rel=1e-6)
 
 
-def test_visual_cortex_spiking_backend():
+def test_visual_cortex_neuromorphic_bridge(checkerboard_image: np.ndarray) -> None:
     snn = SpikingNeuralNetwork(2, weights=[[0.0, 1.0], [0.0, 0.0]])
-    initial = snn.synapses.weights[0][1]
+    initial_weight = snn.synapses.weights[0][1]
     cortex = VisualCortex(spiking_backend=snn)
-    cortex.process([[1, 0], [0, 1]])
-    assert snn.synapses.weights[0][1] != initial
+    result = cortex.process(checkerboard_image)
+
+    assert "neuromorphic" in result
+    payload = result["neuromorphic"]
+    assert len(payload["spike_counts"]) == 2
+    assert any(count > 0 for count in payload["spike_counts"])
+    assert snn.synapses.weights[0][1] != initial_weight
+
+
+def test_auditory_cortex_neuromorphic_bridge(tone_signal: np.ndarray) -> None:
+    snn = SpikingNeuralNetwork(4, weights=np.ones((4, 4)).tolist())
+    cortex = AuditoryCortex(spiking_backend=snn)
+    result = cortex.process(tone_signal)
+
+    assert "neuromorphic" in result
+    payload = result["neuromorphic"]
+    assert len(payload["spike_counts"]) == 4
+    assert any(count > 0 for count in payload["spike_counts"])
+
+
+def test_somatosensory_cortex_neuromorphic_bridge(tactile_grid: np.ndarray) -> None:
+    snn = SpikingNeuralNetwork(3, weights=np.ones((3, 3)).tolist())
+    cortex = SomatosensoryCortex(spiking_backend=snn)
+    result = cortex.process(tactile_grid)
+
+    assert "neuromorphic" in result
+    payload = result["neuromorphic"]
+    assert len(payload["spike_counts"]) == 3
+    assert any(count > 0 for count in payload["spike_counts"])


### PR DESCRIPTION
## Summary
- replace placeholder sensory cortex processors with adapters built on the perception encoders, returning feature-rich outputs and neuromorphic payloads
- add regression coverage for vision, auditory, and tactile pipelines to assert deterministic numeric features and spiking hand-offs

## Testing
- pytest tests/test_sensory_cortex.py

------
https://chatgpt.com/codex/tasks/task_e_68d3d739e0d4832f83b628e2a19a9147