### PR TITLE
Refactor cognitive policy and add streaming brain telemetry

### DIFF
--- a/tests/brain/test_whole_brain_extended.py
+++ b/tests/brain/test_whole_brain_extended.py
@@ -19,13 +19,18 @@ def test_whole_brain_exposes_oscillation_and_motor_metrics():
     result = brain.process_cycle(input_data)
 
     assert "osc_amplitude" in result.metrics
-    assert "osc_synchrony" in result.metrics
+    assert "osc_synchrony_norm" in result.metrics
     assert result.metrics.get("motor_energy", 0.0) >= 0.0
     assert result.metadata.get("oscillation_state")
     assert result.metadata.get("motor_spike_counts")
     assert "feedback_velocity_error" in result.metrics
     assert "feedback_success_rate" in result.metrics
     assert result.metadata.get("feedback_metrics")
+    assert result.metadata.get("policy") == "heuristic"
+    assert result.metadata.get("policy_metadata")["confidence_calibrated"] is True
+    assert result.metadata.get("cycle_errors") is None
     assert brain.motor.cerebellum is brain.cerebellum
     assert brain.last_motor_result is not None
     assert brain.last_decision.get("motor_spike_counts")
+    assert len(brain.decision_history) == 1
+    assert brain.telemetry_log[-1]["plan_length"] >= 1


### PR DESCRIPTION
## Summary
- replace the hard-coded cognitive weighting with a pluggable policy interface, including a heuristic default, calibrated confidence, and richer decision metadata
- redesign the WholeBrainSimulation cycle to consume streaming inputs, persist perception/decision histories, and capture telemetry with defensive error handling
- expand the neuromorphic brain tests to cover the new cognition interface, streaming behaviour, and policy/telemetry outputs

## Testing
- pytest tests/brain/test_whole_brain_neuromorphic.py tests/brain/test_whole_brain_extended.py


------
https://chatgpt.com/codex/tasks/task_e_68d3df9ef830832fac0a838810189e94