### PR TITLE
Refine cerebellum motor control using numeric feedback

### DIFF
--- a/modules/brain/cerebellum.py
+++ b/modules/brain/cerebellum.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from numbers import Real
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List, Mapping
 
 from .motor.actions import MotorCommand, MotorExecutionResult
 
@@ -11,17 +11,83 @@ from .motor.actions import MotorCommand, MotorExecutionResult
 class PurkinjeNetwork:
     """Network of Purkinje cells for refining motor signals."""
 
-    def refine(self, signal: str) -> str:
-        """Refine incoming signals from granule network."""
-        return f"{signal} refined"
+    def __init__(self, *, kp: float = 0.6, ki: float = 0.12, kd: float = 0.08) -> None:
+        self.kp = float(kp)
+        self.ki = float(ki)
+        self.kd = float(kd)
+        self._integral: Dict[str, float] = {}
+        self._previous_error: Dict[str, float] = {}
+
+    def refine(self, signal: Mapping[str, Real], *, update_state: bool = True) -> Dict[str, float]:
+        """Compute PID-style corrections for the provided error signal."""
+
+        corrections: Dict[str, float] = {}
+        for key, value in signal.items():
+            try:
+                error = float(value)
+            except (TypeError, ValueError):
+                continue
+
+            last_integral = self._integral.get(key, 0.0)
+            last_error = self._previous_error.get(key, 0.0)
+
+            integral = last_integral + error
+            derivative = error - last_error
+
+            if update_state:
+                self._integral[key] = integral
+                self._previous_error[key] = error
+
+            correction = self.kp * error + self.ki * integral + self.kd * derivative
+            corrections[key] = correction
+
+        return corrections
 
 
 class GranuleNetwork:
     """Network of granule cells preprocessing inputs."""
 
-    def process(self, input_signal: str) -> str:
-        """Process incoming sensory or motor inputs."""
-        return f"processed {input_signal}"
+    def __init__(self, *, smoothing: float = 0.25) -> None:
+        self.smoothing = float(smoothing)
+        self._running_mean: Dict[str, float] = {}
+
+    def process(
+        self,
+        input_signal: Mapping[str, Real] | MotorExecutionResult | MotorCommand | Iterable[tuple[str, Real]] | None,
+    ) -> Dict[str, float]:
+        """Filter incoming signals and return normalised residual errors."""
+
+        telemetry = self._extract_numeric(input_signal)
+        processed: Dict[str, float] = {}
+
+        for key, value in telemetry.items():
+            baseline = self._running_mean.get(key, 0.0)
+            baseline += self.smoothing * (float(value) - baseline)
+            self._running_mean[key] = baseline
+            processed[key] = float(value) - baseline
+
+        return processed
+
+    def _extract_numeric(
+        self, signal: Mapping[str, Real] | MotorExecutionResult | MotorCommand | Iterable[tuple[str, Real]] | None
+    ) -> Dict[str, float]:
+        if signal is None:
+            return {}
+        if isinstance(signal, MotorExecutionResult):
+            return {key: float(value) for key, value in signal.telemetry.items() if isinstance(value, Real)}
+        if isinstance(signal, MotorCommand):
+            return {key: float(value) for key, value in signal.arguments.items() if isinstance(value, Real)}
+        if isinstance(signal, Mapping):
+            return {key: float(value) for key, value in signal.items() if isinstance(value, Real)}
+        telemetry: Dict[str, float] = {}
+        for item in signal:
+            try:
+                key, value = item
+            except (TypeError, ValueError):
+                continue
+            if isinstance(key, str) and isinstance(value, Real):
+                telemetry[key] = float(value)
+        return telemetry
 
 
 class Cerebellum:
@@ -32,85 +98,119 @@ class Cerebellum:
         self.granule = GranuleNetwork()
         self.learned_signals: List[Dict[str, Any]] = []
         self.metric_history: List[Dict[str, float]] = []
+        self._latest_error_signal: Dict[str, float] = {}
+        self._latest_corrections: Dict[str, float] = {}
+        self._balance_state: Dict[str, float] = {}
 
     def fine_tune(self, motor_command: str | MotorCommand) -> str | MotorCommand:
         """Refine motor commands or command objects for smoother execution."""
 
         if isinstance(motor_command, MotorCommand):
             return self._fine_tune_command(motor_command)
-        processed = self.granule.process(str(motor_command))
-        return self.purkinje.refine(processed)
+        return self._summarise_state()
 
-    def motor_learning(self, feedback: str | Dict[str, Any] | MotorExecutionResult) -> str:
-        """Update internal state using explicit feedback signals."""
+    def motor_learning(self, feedback: str | Dict[str, Any] | MotorExecutionResult) -> Dict[str, Any]:
+        """Update internal state using structured feedback signals."""
 
         record = self._normalise_feedback(feedback)
-        metrics: Dict[str, float] | None = None
-        telemetry = record.get("telemetry")
-        if isinstance(telemetry, dict):
-            metrics = {
-                key: float(value)
-                for key, value in telemetry.items()
-                if isinstance(value, Real)
-            }
+        telemetry = record.get("telemetry", {})
+        numeric_telemetry = {
+            key: float(value)
+            for key, value in dict(telemetry).items()
+            if isinstance(value, Real)
+        }
+
         if record.get("success") is not None:
-            metrics = metrics or {}
-            metrics.setdefault("success_rate", 1.0 if record.get("success") else 0.0)
-        if record.get("error"):
-            metrics = metrics or {}
-            metrics.setdefault("overall_error", 1.0)
-        if metrics:
-            self.update_feedback(metrics)
-        self.learned_signals.append(record)
-        label = record.get("label", record.get("signal", "feedback"))
-        return f"learned from {label}"
+            numeric_telemetry.setdefault("success_rate", 1.0 if record["success"] else 0.0)
 
-    def balance_control(self, sensory_input: str) -> str:
-        """Placeholder for balance control using sensory feedback."""
+        if numeric_telemetry:
+            self.metric_history.append(dict(numeric_telemetry))
 
-        processed = self.granule.process(sensory_input)
-        return f"balance adjusted with {processed}"
+        filtered_error = self.granule.process(numeric_telemetry) if numeric_telemetry else {}
+        self._latest_error_signal = dict(filtered_error)
+        corrections = self.purkinje.refine(filtered_error) if filtered_error else {}
+        self._latest_corrections = dict(corrections)
+
+        sample = {
+            "telemetry": numeric_telemetry,
+            "filtered_error": filtered_error,
+            "corrections": corrections,
+        }
+        if "success" in record:
+            sample["success"] = bool(record["success"])
+        if record.get("label"):
+            sample["label"] = record["label"]
+
+        self.learned_signals.append(sample)
+        return sample
+
+    def balance_control(self, sensory_input: Mapping[str, Real] | str) -> Dict[str, Any]:
+        """Update balance estimates using structured sensory feedback."""
+
+        metrics = self._parse_structured_input(sensory_input)
+        if not metrics:
+            return {"adjustments": {}, "filtered": {}, "status": "insufficient_data"}
+
+        filtered = self.granule.process(metrics)
+        adjustments = self.purkinje.refine(filtered, update_state=False)
+        self._balance_state = dict(adjustments)
+        return {"adjustments": adjustments, "filtered": filtered}
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
     def _fine_tune_command(self, command: MotorCommand) -> MotorCommand:
-        adjustments = self._compute_adjustments()
-        metadata = {"cerebellum": adjustments}
-        argument_updates = adjustments.get("arguments", {})
+        corrections = dict(self._latest_corrections)
+        if not corrections and self._latest_error_signal:
+            corrections = self.purkinje.refine(self._latest_error_signal)
+            self._latest_corrections = dict(corrections)
+
+        argument_updates = self._compute_argument_updates(command.arguments, corrections)
+        metadata = {
+            "cerebellum": {
+                "training_samples": len(self.learned_signals),
+                "metric_samples": len(self.metric_history),
+                "filtered_error": dict(self._latest_error_signal),
+                "applied_corrections": dict(corrections),
+            }
+        }
         return command.with_updates(arguments=argument_updates, metadata=metadata)
 
-    def _compute_adjustments(self) -> Dict[str, Any]:
-        count = len(self.learned_signals)
-        if count == 0:
-            return {"arguments": {}, "training_samples": 0}
-        failures = sum(1 for rec in self.learned_signals if not rec.get("success", True))
-        gain = 1.0 + min(count * 0.05, 0.5)
-        damping = min(failures * 0.1, 0.6)
-        adjustments: Dict[str, Any] = {
-            "arguments": {"gain": gain, "damping": damping},
-            "training_samples": count,
-            "failure_samples": failures,
-        }
-        if self.metric_history:
-            recent = self.metric_history[-min(len(self.metric_history), 5) :]
-            if recent:
-                avg_velocity = sum(m.get("velocity_error", 0.0) for m in recent) / len(recent)
-                avg_stability = sum(m.get("stability_error", 0.0) for m in recent) / len(recent)
-                avg_accuracy = sum(m.get("accuracy_error", 0.0) for m in recent) / len(recent)
-                adjustments["arguments"].update(
-                    {
-                        "gain": max(0.5, adjustments["arguments"]["gain"] - avg_velocity * 0.3),
-                        "damping": min(1.0, adjustments["arguments"]["damping"] + avg_stability * 0.4),
-                        "accuracy_bias": max(0.0, min(1.0, 1.0 - avg_accuracy)),
-                    }
-                )
-                adjustments["metric_samples"] = len(self.metric_history)
-        return adjustments
+    def _compute_argument_updates(
+        self, arguments: Mapping[str, Any], corrections: Mapping[str, float]
+    ) -> Dict[str, Any]:
+        updates: Dict[str, Any] = {}
+        for key, value in arguments.items():
+            correction_key = None
+            if isinstance(value, Real):
+                if key in corrections:
+                    correction_key = key
+                elif f"{key}_error" in corrections:
+                    correction_key = f"{key}_error"
+                elif f"{key}_delta" in corrections:
+                    correction_key = f"{key}_delta"
+                elif f"{key}_deviation" in corrections:
+                    correction_key = f"{key}_deviation"
+
+            if correction_key is None:
+                continue
+
+            correction = float(corrections[correction_key])
+            if isinstance(value, Real):
+                updates[key] = float(value) - correction
+        return updates
+
+    def _summarise_state(self) -> str:
+        if not self.metric_history:
+            return "cerebellum: no telemetry"
+        latest = self.metric_history[-1]
+        parts = [f"{key}:{latest[key]:.3f}" for key in sorted(latest)[:4]]
+        return " | ".join(parts)
 
     def _normalise_feedback(self, feedback: str | Dict[str, Any] | MotorExecutionResult) -> Dict[str, Any]:
         if isinstance(feedback, str):
-            return {"signal": feedback, "label": feedback, "success": False}
+            telemetry = self._parse_structured_input(feedback)
+            return {"signal": feedback, "label": feedback, "success": False, "telemetry": telemetry}
         if isinstance(feedback, dict):
             data = dict(feedback)
             data.setdefault("label", str(data.get("signal", "feedback")))
@@ -121,6 +221,25 @@ class Cerebellum:
             "success": feedback.success,
             "telemetry": dict(feedback.telemetry),
         }
+
+    def _parse_structured_input(self, sensory_input: Mapping[str, Real] | str) -> Dict[str, float]:
+        if isinstance(sensory_input, Mapping):
+            return {
+                key: float(value)
+                for key, value in sensory_input.items()
+                if isinstance(value, Real)
+            }
+        metrics: Dict[str, float] = {}
+        tokens = sensory_input.replace(",", " ").split()
+        for token in tokens:
+            if ":" not in token:
+                continue
+            key, value = token.split(":", 1)
+            try:
+                metrics[key] = float(value)
+            except ValueError:
+                continue
+        return metrics
 
     def update_feedback(self, metrics: Dict[str, Any]) -> None:
         """Integrate structured metric feedback for multi-channel learning."""

--- a/tests/test_cerebellum_integration.py
+++ b/tests/test_cerebellum_integration.py
@@ -1,21 +1,87 @@
 import os
 import sys
+from typing import Dict
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from modules.brain import MotorCortex, Cerebellum
+from modules.brain import Cerebellum, MotorCortex
+from modules.brain.motor.actions import MotorCommand, MotorExecutionResult
 
 
-def test_cerebellum_training_integration():
+def _simulate_error_reduction(
+    command: MotorCommand, tuned: MotorCommand, telemetry: Dict[str, float]
+) -> Dict[str, float]:
+    """Compute simulated post-adjustment error magnitudes."""
+
+    errors_after: Dict[str, float] = {}
+    for metric, error in telemetry.items():
+        if not metric.endswith("_error"):
+            continue
+        arg_name = metric[: -len("_error")]
+        original_value = command.arguments.get(arg_name)
+        tuned_value = tuned.arguments.get(arg_name)
+        if isinstance(original_value, (int, float)) and isinstance(tuned_value, (int, float)):
+            applied_change = float(original_value) - float(tuned_value)
+            errors_after[metric] = float(error) - applied_change
+    return errors_after
+
+
+def test_cerebellum_motor_learning_and_refinement_reduces_error():
+    cerebellum = Cerebellum()
+    command = MotorCommand(
+        tool="arm",
+        operation="reach",
+        arguments={"position": 1.0, "velocity": 0.5},
+        metadata={},
+    )
+    telemetry = {"position_error": 0.32, "velocity_error": -0.18}
+    feedback = MotorExecutionResult(success=False, output=None, telemetry=telemetry, error="overshoot")
+
+    learning_summary = cerebellum.motor_learning(feedback)
+    assert learning_summary["telemetry"]["position_error"] == telemetry["position_error"]
+    assert learning_summary["telemetry"]["velocity_error"] == telemetry["velocity_error"]
+    assert learning_summary["filtered_error"]
+    assert learning_summary["corrections"]
+
+    tuned_command = cerebellum.fine_tune(command)
+    assert isinstance(tuned_command, MotorCommand)
+    errors_after = _simulate_error_reduction(command, tuned_command, telemetry)
+    for metric, error_before in telemetry.items():
+        if metric.endswith("_error") and metric in errors_after:
+            assert abs(errors_after[metric]) < abs(error_before)
+    cerebellum_hint = cerebellum.fine_tune("status")
+    assert isinstance(cerebellum_hint, str)
+    assert cerebellum_hint
+
+
+def test_cerebellum_balance_control_structured_feedback():
+    cerebellum = Cerebellum()
+    sensory = {"tilt": 0.2, "acceleration": -0.05}
+    response = cerebellum.balance_control(sensory)
+    assert "adjustments" in response
+    assert isinstance(response["filtered"], dict)
+    assert set(response["adjustments"]).issubset({"tilt", "acceleration"})
+
+    text_response = cerebellum.balance_control("tilt:0.1 sway:-0.02")
+    assert "adjustments" in text_response
+
+
+def test_motor_cortex_training_integrates_structured_feedback():
     cerebellum = Cerebellum()
     cortex = MotorCortex(cerebellum=cerebellum)
-    result = cortex.train("overshoot")
-    assert "learned" in result and "overshoot" in result
-    executed = cortex.execute_action("move")
-    assert "refined" in executed
+    feedback = MotorExecutionResult(
+        success=False,
+        output=None,
+        telemetry={"position_error": 0.25, "stability_error": 0.15},
+        error="drift",
+    )
+    report = cortex.train(feedback)
+    assert isinstance(report, dict)
+    assert report["telemetry"]["position_error"] == 0.25
+    assert cerebellum.metric_history
 
-
-def test_balance_control_placeholder():
-    cerebellum = Cerebellum()
-    response = cerebellum.balance_control("tilt")
-    assert "balance adjusted" in response and "tilt" in response
+    tuned = cortex.cerebellum.fine_tune(
+        MotorCommand(tool="arm", operation="reach", arguments={"position": 0.8}, metadata={})
+    )
+    assert isinstance(tuned, MotorCommand)
+    assert tuned.metadata["cerebellum"]["applied_corrections"]


### PR DESCRIPTION
## Summary
- replace the cerebellar granule and Purkinje networks with telemetry-driven filtering and PID-style corrections
- rework cerebellar learning and balance control to ingest structured feedback and expose applied corrections on motor commands
- expand cerebellum integration tests to validate error reduction and updated MotorCortex interactions

## Testing
- pytest tests/test_cerebellum_integration.py tests/test_motor_actuator_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68d3e2af58b8832f86997897f5a402be